### PR TITLE
Adds a .match method to SubType instance

### DIFF
--- a/src/EnumTag.js
+++ b/src/EnumTag.js
@@ -4,13 +4,13 @@
 const checkType = (props, args) =>
     !props? true : props.length === args.length;
 
-// EnumTag :: String -> ?Array String -> ...a -> EnumTagType
-export const EnumTag = (name, props) => (...args) => {
+// EnumTag :: (String, EnumType, ?Array String) -> ...a -> EnumTagType
+export const EnumTag = (name, Type, props) => (...args) => {
     if(!checkType(props, args)) {
         throw new Error(`Constructor ${name} expected ${props.length} arguments, ${args.length} passed`);
     }
 
-    return {
+    const self = {
         // args :: Array *
         args,
         // name :: String
@@ -18,10 +18,14 @@ export const EnumTag = (name, props) => (...args) => {
         // props :: ?Array String
         props,
         // is :: String | EnumTagType | EnumToken ~> Boolean
-        is: otherType => typeof otherType === 'string'
-            ? (name === otherType)
-            : (name === otherType.name),
+        is: otherType => (typeof otherType === 'string')
+            ? name === otherType
+            : name === otherType.name,
     };
+
+    self.match = pattern => Type.match(self, pattern);
+
+    return self;
 };
 
 export default EnumTag;

--- a/src/EnumType.js
+++ b/src/EnumType.js
@@ -8,12 +8,10 @@ const EnumType = enumTokens => {
         : Object.keys(enumTokens).map(name => EnumToken({ name, props: enumTokens[name] }));
 
     const self = {
-        // {String} :: EnumAction
-        ...reduceTypeConstructors(types),
-
         // types :: Array String
         types: types.map(prop(['name'])),
 
+        // isValidConstructor :: String -> Boolean
         isValidConstructor: c => c === '_' || !!self[c],
 
         // matchToDefault :: Object (...a -> b) -> Array a ~> b
@@ -43,7 +41,11 @@ const EnumType = enumTokens => {
         caseOf: patternMap => token => self.match(token, patternMap),
     };
 
-    return self;
+    return {
+        // {String} :: EnumAction
+        ...reduceTypeConstructors(self, types),
+        ...self,
+    };
 };
 
 export default EnumType;

--- a/src/EnumType.js
+++ b/src/EnumType.js
@@ -7,7 +7,7 @@ const EnumType = enumTokens => {
         ? enumTokens.map(name => EnumToken({ name }))
         : Object.keys(enumTokens).map(name => EnumToken({ name, props: enumTokens[name] }));
 
-    const self = {
+    let self = {
         // types :: Array String
         types: types.map(prop(['name'])),
 
@@ -41,11 +41,13 @@ const EnumType = enumTokens => {
         caseOf: patternMap => token => self.match(token, patternMap),
     };
 
-    return {
+    self = {
         // {String} :: EnumAction
         ...reduceTypeConstructors(self, types),
         ...self,
     };
+
+    return self;
 };
 
 export default EnumType;

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,11 +5,11 @@ import EnumTag from './EnumTag';
 // EnumToken :: Object -> EnumToken
 export const EnumToken = ({ name, props }) => ({ name, props });
 
-// reduceTypeConstructors :: Array EnumToken -> Object EnumAction
-export const reduceTypeConstructors = types =>
-    types.reduce((obj, type) => ({
+// reduceTypeConstructors :: (EnumType, Array EnumToken) -> Object EnumAction
+export const reduceTypeConstructors = (Type, subTypes) =>
+    subTypes.reduce((obj, subtype) => ({
         ...obj,
-        [type.name]: EnumTag(type.name, type.props),
+        [subtype.name]: EnumTag(subtype.name, Type, subtype.props),
     }), {});
 
 // error :: String -> ()

--- a/test/EnumTag.test.js
+++ b/test/EnumTag.test.js
@@ -1,13 +1,16 @@
 
+import EnumType from '../src/EnumType';
 import EnumTag from '../src/EnumTag';
+
+const TestType = EnumType([ 'Type', 'TypeWithArgs', 'Tag', 'NewTag' ]);
 
 describe('EnumTag', () => {
 
     describe('#constructor', () => {
 
         it('should have name, props and args', () => {
-            const Tag = EnumTag('Type');
-            const TagWithArgs = EnumTag('TypeWithArgs', [ 'id', 'message' ]);
+            const Tag = EnumTag('Type', TestType);
+            const TagWithArgs = EnumTag('TypeWithArgs', TestType, [ 'id', 'message' ]);
 
             const tag = Tag();
             const tagWithArgs = TagWithArgs(5, 'Hello world');
@@ -22,7 +25,7 @@ describe('EnumTag', () => {
         });
 
         it('should throw error if there is a mismatch in the props and arguements', () => {
-            const Tag = EnumTag('Type', [ 'a', 'b' ]);
+            const Tag = EnumTag('Type', TestType, [ 'a', 'b' ]);
 
             expect(() => Tag(1, 2)).not.toThrowError();
             expect(() => Tag()).toThrowError();
@@ -35,9 +38,9 @@ describe('EnumTag', () => {
         
         it('should return true for equivalent tokens and false otherwise', () => {
 
-            const Tag = EnumTag('Tag');
-            const Tag1 = EnumTag('Tag');
-            const Tag2 = EnumTag('NewTag');
+            const Tag = EnumTag('Tag', TestType);
+            const Tag1 = EnumTag('Tag', TestType);
+            const Tag2 = EnumTag('NewTag', TestType);
 
             expect(Tag().is(Tag1())).toBeTruthy();
             expect(Tag().is(Tag2())).not.toBeTruthy();

--- a/test/EnumTag.test.js
+++ b/test/EnumTag.test.js
@@ -46,4 +46,83 @@ describe('EnumTag', () => {
             expect(Tag().is(Tag2())).not.toBeTruthy();
         });
     });
+
+    describe('#match', () => {
+        
+        it('should match the correct function and call it', () => {
+            const Type = EnumType([ 'Add', 'Delete' ]);
+
+            const action = Type.Add();
+
+            const onAdd = jest.fn(() => 'Adding');
+            const result = action.match({
+                Add: onAdd,
+                Delete: () => 'Deleting',
+                _: () => 'Default',
+            });
+
+            expect(result).toBe('Adding');
+            expect(onAdd).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call the default function when the action is not specified', () => {
+            const Type = EnumType([ 'Add', 'Delete' ]);
+
+            const action = Type.Delete();
+
+            const handleDefault = jest.fn(() => 'Default');
+            const result = action.match({
+                Add: () => 'Adding',
+                _: handleDefault,
+            });
+
+            expect(result).toBe('Default');
+            expect(handleDefault).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call the default function when the action is not specified', () => {
+            const Type = EnumType([ 'Add', 'Delete' ]);
+
+            const action = Type.Delete();
+
+            expect(() => action.match({
+                Add: () => 'Adding',
+            })).toThrowError();
+        });
+
+        it('should match the correct function and call it with the constructor arguements', () => {
+            const Type = EnumType([ 'Add', 'Delete' ]);
+
+            const action = Type.Add('Hello', 'World');
+
+            const onAdd = jest.fn((str1, str2) => `Adding - ${str1} ${str2}`);
+            const result = action.match({
+                Add: onAdd,
+                Delete: () => 'Deleting',
+                _: () => 'Default',
+            });
+
+            expect(result).toBe('Adding - Hello World');
+            expect(onAdd).toHaveBeenCalledTimes(1);
+        });
+
+        it('should match the correct function and call it with the constructor arguements', () => {
+            const Type = EnumType({
+                Add: [ 'id', 'text' ],
+                Delete: [ 'id' ],
+            });
+
+            const pattern = {
+                Add: jest.fn((id, name) => `Adding - [${id}] ${name}`),
+                Delete: jest.fn(id => `Deleting - [${id}]`),
+            };
+            const resultOnAdd = Type.Add(5, 'Hello World').match(pattern);
+            const resultOnDelete = Type.Delete(5).match(pattern);
+
+            expect(resultOnAdd).toBe('Adding - [5] Hello World');
+            expect(pattern.Add).toHaveBeenCalledTimes(1);
+            expect(resultOnDelete).toBe('Deleting - [5]');
+            expect(pattern.Delete).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,8 @@
 
+import EnumType from '../src/EnumType';
 import { reduceTypeConstructors, EnumToken } from '../src/utils';
+
+const TestType = EnumType([ 'Action1', 'Action2', 'Action3' ]);
 
 describe('utils', () => {
 
@@ -12,7 +15,7 @@ describe('utils', () => {
                 EnumToken({ name: 'Action3' }),
             ];
     
-            const result = reduceTypeConstructors(tokens);
+            const result = reduceTypeConstructors(TestType, tokens);
     
             expect(result.Action1).toBeInstanceOf(Function);
             expect(result.Action2).toBeInstanceOf(Function);


### PR DESCRIPTION
Fixes #2 

### Current API
```js
Type.match(a, {
    SubType1: () => console.log(1),
    SubType2: () => console.log(2),
});
```

### Alternate API
```js
a.match({
    SubType1: () => console.log(1),
    SubType2: () => console.log(2),
});
```
